### PR TITLE
feat: 드롭다운 컴포넌트 구현

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,8 @@ module.exports = {
   },
   plugins: ["react"],
   rules: {
-    "react/react-in-jsx-scope": "off",
+    "react/react-in-jsx-scope": "off", // JSX를 사용할 때 React가 일일이 import되지 않으면 에러 -> off
+    "no-unused-vars": "off", // 사용하지 않는 변수가 있을 때 에러 -> off
+    "react/prop-types": "off", // prop의 타입을 정의해주지 않으면 에러 -> off
   },
 };

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2",
+  "ignorePaths": [],
+  "dictionaryDefinitions": [],
+  "dictionaries": [],
+  "words": [
+    "Noto",
+    "Pretendard"
+  ],
+  "ignoreWords": [],
+  "import": []
+}

--- a/src/assets/icons/arrow_down.svg
+++ b/src/assets/icons/arrow_down.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 4.76942L8 11.231L14 4.76942" stroke="#181818" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/arrow_top.svg
+++ b/src/assets/icons/arrow_top.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="ic / arrow_top">
+<path id="Polygon 1" d="M2 11.2306L8 4.76904L14 11.2306" stroke="#181818" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/components/Dropdown/Dropdown.jsx
+++ b/src/components/Dropdown/Dropdown.jsx
@@ -1,0 +1,63 @@
+import * as S from "./Dropdown.style";
+import arrowDown from "assets/icons/arrow_down.svg";
+import arrowUp from "assets/icons/arrow_top.svg";
+import { useEffect, useRef, useState } from "react";
+
+function Dropdown({ options }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isError, setIsError] = useState(false);
+  const [selectedValue, setSelectedValue] = useState(options[0]);
+  const ref = useRef(null);
+
+  const handleClickButton = (e) => {
+    e.stopPropagation();
+    setIsOpen(!isOpen);
+  };
+
+  const handleClickOutside = (e) => {
+    if (ref.current && !ref.current.contains(e.target)) {
+      setIsOpen(false);
+    }
+  };
+
+  const handleClickListItem = (e) => {
+    setSelectedValue(e.target.innerText);
+    setIsOpen(false);
+  };
+
+  useEffect(() => {
+    document.addEventListener("click", handleClickOutside);
+    return () => {
+      document.removeEventListener("click", handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <S.DropdownContainer>
+      <S.ButtonContainer
+        active={isOpen}
+        error={isError}
+        onClick={handleClickButton}
+      >
+        <p>{selectedValue}</p>
+        {isOpen ? (
+          <img src={arrowUp} alt="위 화살표" />
+        ) : (
+          <img src={arrowDown} alt="아래 화살표" />
+        )}
+      </S.ButtonContainer>
+      {isError && <S.ErrorMessage>Error Message</S.ErrorMessage>}
+      {isOpen && (
+        <S.ListContainer ref={ref}>
+          {options.map((value, index) => (
+            <S.ListItem key={index} onClick={handleClickListItem}>
+              {value}
+            </S.ListItem>
+          ))}
+        </S.ListContainer>
+      )}
+    </S.DropdownContainer>
+  );
+}
+
+export default Dropdown;

--- a/src/components/Dropdown/Dropdown.style.js
+++ b/src/components/Dropdown/Dropdown.style.js
@@ -1,0 +1,76 @@
+import { styled } from "styled-components";
+import { COLORS } from "styles/palette";
+
+export const DropdownContainer = styled.div`
+  width: 32rem;
+  margin: 10rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+`;
+
+export const ButtonContainer = styled.button`
+  appearance: none;
+  display: flex;
+  justify-content: space-between;
+  width: 32rem;
+  padding: 1.2rem 1.6rem;
+  align-items: center;
+  border-radius: 0.8rem;
+  border-style: solid;
+  border-width: ${({ active }) => (active ? 0.2 : 0.1)}rem;
+  border-color: ${({ error, active }) =>
+    error ? COLORS.ERROR : active ? COLORS.GRAY_500 : COLORS.GRAY_300};
+  color: ${({ error, active }) =>
+    error || active ? COLORS.GRAY_900 : COLORS.GRAY_500};
+  font-size: 1.6rem;
+  line-height: 2.6rem;
+  letter-spacing: -0.016rem;
+  background: ${({ disabled }) => disabled && COLORS.GRAY_100};
+
+  &:hover {
+    border-color: ${COLORS.GRAY_500};
+  }
+
+  &:focus {
+    outline: 0;
+    border-color: ${COLORS.GRAY_500};
+    color: ${COLORS.GRAY_900};
+    border-width: 0.2rem;
+  }
+`;
+
+export const ErrorMessage = styled.p`
+  margin-top: -0.4rem;
+  color: ${COLORS.ERROR};
+  font-size: 1.2rem;
+  line-height: 150%;
+  letter-spacing: -0.006rem;
+`;
+
+export const ListContainer = styled.ul`
+  width: 32rem;
+  display: inline-flex;
+  padding: 1rem 0.1rem;
+  flex-direction: column;
+  align-items: flex-start;
+  border-radius: 0.8rem;
+  border: 0.1rem solid ${COLORS.GRAY_300};
+  background: ${COLORS.WHITE};
+  box-shadow: 0 0.2rem 1.2rem 0 rgba(0, 0, 0, 0.08);
+  cursor: pointer;
+`;
+
+export const ListItem = styled.li`
+  display: flex;
+  width: 31.6rem;
+  padding: 1.2rem 1.6rem;
+  align-items: center;
+  font-size: 1.6rem;
+  line-height: 2.6rem;
+  letter-spacing: -0.016rem;
+
+  ${ListContainer} &:hover {
+    background: ${COLORS.GRAY_100};
+  }
+`;

--- a/src/components/Dropdown/Dropdown.style.js
+++ b/src/components/Dropdown/Dropdown.style.js
@@ -3,7 +3,6 @@ import { COLORS } from "styles/palette";
 
 export const DropdownContainer = styled.div`
   width: 32rem;
-  margin: 10rem;
   display: flex;
   flex-direction: column;
   gap: 0.8rem;

--- a/src/components/Dropdown/Dropdown.style.js
+++ b/src/components/Dropdown/Dropdown.style.js
@@ -1,0 +1,75 @@
+import { styled } from "styled-components";
+import { COLORS } from "styles/palette";
+
+export const DropdownContainer = styled.div`
+  width: 32rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+`;
+
+export const ButtonContainer = styled.button`
+  appearance: none;
+  display: flex;
+  justify-content: space-between;
+  width: 32rem;
+  padding: 1.2rem 1.6rem;
+  align-items: center;
+  border-radius: 0.8rem;
+  border-style: solid;
+  border-width: ${({ active }) => (active ? 0.2 : 0.1)}rem;
+  border-color: ${({ error, active }) =>
+    error ? COLORS.ERROR : active ? COLORS.GRAY_500 : COLORS.GRAY_300};
+  color: ${({ error, active }) =>
+    error || active ? COLORS.GRAY_900 : COLORS.GRAY_500};
+  font-size: 1.6rem;
+  line-height: 2.6rem;
+  letter-spacing: -0.016rem;
+  background: ${({ disabled }) => disabled && COLORS.GRAY_100};
+
+  &:hover {
+    border-color: ${COLORS.GRAY_500};
+  }
+
+  &:focus {
+    outline: 0;
+    border-color: ${COLORS.GRAY_500};
+    color: ${COLORS.GRAY_900};
+    border-width: 0.2rem;
+  }
+`;
+
+export const ErrorMessage = styled.p`
+  margin-top: -0.4rem;
+  color: ${COLORS.ERROR};
+  font-size: 1.2rem;
+  line-height: 150%;
+  letter-spacing: -0.006rem;
+`;
+
+export const ListContainer = styled.ul`
+  width: 32rem;
+  display: inline-flex;
+  padding: 1rem 0.1rem;
+  flex-direction: column;
+  align-items: flex-start;
+  border-radius: 0.8rem;
+  border: 0.1rem solid ${COLORS.GRAY_300};
+  background: ${COLORS.WHITE};
+  box-shadow: 0 0.2rem 1.2rem 0 rgba(0, 0, 0, 0.08);
+  cursor: pointer;
+`;
+
+export const ListItem = styled.li`
+  display: flex;
+  width: 31.6rem;
+  padding: 1.2rem 1.6rem;
+  align-items: center;
+  font-size: 1.6rem;
+  line-height: 2.6rem;
+  letter-spacing: -0.016rem;
+
+  ${ListContainer} &:hover {
+    background: ${COLORS.GRAY_100};
+  }
+`;

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Dropdown";

--- a/src/styles/reset.js
+++ b/src/styles/reset.js
@@ -41,4 +41,9 @@ export const reset = css`
     background-color: unset;
     cursor: pointer;
   }
+
+  ul {
+    list-style-type: none;
+    padding-left: 0;
+  }
 `;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,8 @@
+export const RELATIONSHIP = ["친구", "지인", "동료", "관계"];
+
+export const FONT_SELECT = [
+  "Noto Sans",
+  "Pretendard",
+  "나눔명조",
+  "나눔손글씨 손편지체",
+];


### PR DESCRIPTION
# 실제 렌더링 모습

## Dropdown_Inactive

![Dropdown_Inactive](https://github.com/codeit-part2-team4/rolling/assets/117700203/2664d356-7cdd-4cf3-8929-8774e9c4a20e)

## Dropdown_Hover

![Dropdown_Hover](https://github.com/codeit-part2-team4/rolling/assets/117700203/8b57a4ff-be76-495f-aa3f-c30ef551c68d)

## Dropdown_Focused

![Dropdown_Focused](https://github.com/codeit-part2-team4/rolling/assets/117700203/fae29807-1d77-4e70-b0fc-d5b071684688)

## Dropdown_Actived

![Dropdown_Actived](https://github.com/codeit-part2-team4/rolling/assets/117700203/1dbc17f9-eb87-4c60-a3d4-97263ad1387e)

## Dropdown_List_Hover

![Dropdown_List_Hover](https://github.com/codeit-part2-team4/rolling/assets/117700203/9c7fa5e5-ad6f-418d-befa-1515df1f1395)

## Dropdown_Disabled

![Dropdown_Disabled](https://github.com/codeit-part2-team4/rolling/assets/117700203/2e881f8d-e92b-4cc6-a718-71ed7ef4103f)

## Dropdown_Error

![Dropdown_Error](https://github.com/codeit-part2-team4/rolling/assets/117700203/ff9a7953-46d3-4f34-b5d0-74235cf050d2)

# 구현 설명

```jsx
// App.jsx

import Dropdown from "components/Dropdown";
import GlobalStyle from "styles/GlobalStyle";
import { FONT_SELECT } from "utils/constants";

function App() {
  return (
    <>
      <GlobalStyle />
      <div>
        <Dropdown options={FONT_SELECT} />
      </div>
    </>
  );
}

export default App;
```

- 테스트를 위해 `App.jsx`에서 `Dropdown` 컴포넌트가 렌더링되게 해준 상태에서 작업
→ `push`할 때 지울 예정
- `Dropdown`은 prop으로 배열을 받음

```jsx
// utils/constants.js

export const RELATIONSHIP = ["친구", "지인", "동료", "관계"];

export const FONT_SELECT = [
  "Noto Sans",
  "Pretendard",
  "나눔명조",
  "나눔손글씨 손편지체",
];
```

- 이때 `REALATIONSHIP`과 `FONT_SELECT`라는 배열을 미리 만들어서 테스트
- 피그마 시안 상 드롭다운이 쓰이는 경우가 이 두 가지

```jsx
// Dropdown.jsx

import * as S from "./Dropdown.style";
import arrowDown from "assets/icons/arrow_down.svg";
import arrowUp from "assets/icons/arrow_top.svg";
import { useEffect, useRef, useState } from "react";

function Dropdown({ options }) {
  const [isOpen, setIsOpen] = useState(false);
  const [isError, setIsError] = useState(false);
  const [selectedValue, setSelectedValue] = useState(options[0]);
  const ref = useRef(null);

  const handleClickButton = (e) => {
    e.stopPropagation();
    setIsOpen(!isOpen);
  };

  const handleClickOutside = (e) => {
    if (ref.current && !ref.current.contains(e.target)) {
      setIsOpen(false);
    }
  };

  const handleClickListItem = (e) => {
    setSelectedValue(e.target.innerText);
    setIsOpen(false);
  };

  useEffect(() => {
    document.addEventListener("click", handleClickOutside);
    return () => {
      document.removeEventListener("click", handleClickOutside);
    };
  }, []);

  return (
    <S.DropdownContainer>
      <S.ButtonContainer
        active={isOpen}
        error={isError}
        onClick={handleClickButton}
      >
        <p>{selectedValue}</p>
        {isOpen ? (
          <img src={arrowUp} alt="위 화살표" />
        ) : (
          <img src={arrowDown} alt="아래 화살표" />
        )}
      </S.ButtonContainer>
      {isError && <S.ErrorMessage>Error Message</S.ErrorMessage>}
      {isOpen && (
        <S.ListContainer ref={ref}>
          {options.map((value, index) => (
            <S.ListItem key={index} onClick={handleClickListItem}>
              {value}
            </S.ListItem>
          ))}
        </S.ListContainer>
      )}
    </S.DropdownContainer>
  );
}

export default Dropdown;
```

- `Dropdown` 컴포넌트는 `true` 혹은 `false`를 가지는 `isOpen` state 값에 따라서 보여지는 리스트 부분과 항상 보여지는 버튼 부분으로 구성
- 리스트는 부모 컴포넌트에서 `prop`으로 받아온 배열을 `map`으로 렌더링함
- 버튼은 `isOpen`을 prop으로 받아서 동적으로 스타일링함
- 버튼은 `onClick`으로 `handleClickButton`을 실행함
`handleClickButton`은 버튼을 눌렀을 때 `isOpen` state를 변경해서 리스트를 열어줌
이때 이벤트 버블링을 막아주지 않으면 다른 이벤트 핸들러에 의해 열자마자 리스트가 닫힘
- 버튼에 렌더링되는 텍스트는 `selectedValue` state의 값을 사용
- `selectedValue` state는 리스트의 요소를 클릭할 때마다 `handleClickListItem`이 실행되어서 해당 요소의 값으로 변경되도록 함
- `isOpen`의 값에 따라서(리스트의 열고닫힘에 따라서) 위 화살표나 아래 화살표가 보이도록 함
- 리스트가 열렸을 때 화면의 다른 영역을 눌렀을 때도 닫을 수 있도록 `useRef` 훅과 `handleClickOutside` 함수를 사용
- `handleClickOutside` 함수는 클릭 이벤트의 타겟이 `ref.current`, 즉 `ListContainer` 외부에 있다면 `isOpen` state의 값을 `false`로 바꿔서 리스트를 닫음

- 만약 `ButtonContainer`가 `disabled`를 prop으로 받는다면 해당 prop을 스타일드 컴포넌트에서 받아서 동적으로 스타일링
- 만약 임시로 만들어 놓은 `isError` state가 `true`가 된다면 해당 prop을 스타일드 컴포넌트에서 받아서 동적으로 스타일링하고 `ErrorMessage` 컴포넌트를 렌더링함

# 추가 사항

- 작업을 하다가 eslint가 불필요하게 에러를 출력한다고 생각하는 규칙을 `off` 했습니다.
- 다른 분들도 이후에 작업 중에 'eslint의 규칙 때문에 올바른 코드인데도 에러가 나와서 방해가 된다', '다른 사람이 커스텀한 규칙 때문에 불편하다'라는 내용이 있으면 일단 `.eslintrc.js`에 추가로 작성해서 사용하시면 될 것 같습니다.
- `cspell.json` 파일에 단어를 추가하면 eslint가 해당 단어에 대해서 맞춤법이 틀렸다고 지적하지 않습니다. 저 같은 경우에는 이번 작업에서 Pretendard, Noto와 같은 단어에 대해서 등록해놓았습니다. 작업하시면서 이 부분도 추가해주시면 좋을 것 같습니다.
- 스타일 초기화하는 `reset.js`에서 `ul` 태그의 기본 스타일링을 비활성화하도록 추가했습니다. 추후에 이 부분 때문에 스타일링이 잘 되지 않는다면 확인해주시면 될 것 같습니다.