### PR TITLE
feat: 배지 구현

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,8 @@ module.exports = {
   },
   plugins: ["react"],
   rules: {
-    "react/react-in-jsx-scope": "off",
+    "react/react-in-jsx-scope": "off", // JSX를 사용할 때 React가 일일이 import되지 않으면 에러 -> off
+    "no-unused-vars": "off", // 사용하지 않는 변수가 있을 때 에러 -> off
+    "react/prop-types": "off", // prop의 타입을 정의해주지 않으면 에러 -> off
   },
 };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+import Emoji from "components/Badges/Emoji";
 import GlobalStyle from "styles/GlobalStyle";
 
 function App() {
@@ -9,7 +10,7 @@ function App() {
   return (
     <>
       <GlobalStyle />
-      <div></div>
+      <div style={style}></div>
     </>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,11 @@
 import GlobalStyle from "styles/GlobalStyle";
 
 function App() {
+  const style = {
+    display: "flex",
+    gap: "1rem",
+    padding: "5rem",
+  };
   return (
     <>
       <GlobalStyle />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,3 @@
-import From from "components/Badges/From";
 import GlobalStyle from "styles/GlobalStyle";
 
 function App() {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,16 +1,11 @@
-import Emoji from "components/Badges/Emoji";
+import From from "components/Badges/From";
 import GlobalStyle from "styles/GlobalStyle";
 
 function App() {
-  const style = {
-    display: "flex",
-    gap: "1rem",
-    padding: "5rem",
-  };
   return (
     <>
       <GlobalStyle />
-      <div style={style}></div>
+      <div></div>
     </>
   );
 }

--- a/src/components/Badges/Emoji/Emoji.jsx
+++ b/src/components/Badges/Emoji/Emoji.jsx
@@ -1,0 +1,18 @@
+import * as S from "./Emoji.style";
+
+function Emoji({ emoji, count }) {
+  return (
+    <S.Wrapper>
+      <span>{emoji}</span>
+      <span>{count}</span>
+    </S.Wrapper>
+  );
+}
+
+const Container = ({ children }) => {
+  return <S.Container>{children}</S.Container>;
+};
+
+Emoji.Container = Container;
+
+export default Emoji;

--- a/src/components/Badges/Emoji/Emoji.style.js
+++ b/src/components/Badges/Emoji/Emoji.style.js
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+import { COLORS } from "styles/palette";
+
+export const Wrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.8rem 1.2rem;
+  width: 6.6rem;
+  height: 3.6rem;
+  border-radius: 3.2rem;
+  background: rgba(0, 0, 0, 0.54);
+  color: ${COLORS.WHITE};
+  font-size: 1.6rem;
+  font-weight: 400;
+  line-height: 2rem;
+`;
+
+export const Container = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+`;

--- a/src/components/Badges/Emoji/index.js
+++ b/src/components/Badges/Emoji/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Emoji";

--- a/src/components/Badges/From/From.jsx
+++ b/src/components/Badges/From/From.jsx
@@ -1,0 +1,18 @@
+import * as S from "./From.style";
+
+function From({ imgUrls, count }) {
+  return (
+    <S.Container>
+      {imgUrls?.map((url, index) => (
+        <S.ImgContainer key={index} index={index}>
+          <S.Img src={url} />
+        </S.ImgContainer>
+      ))}
+      <S.CountContainer index={imgUrls?.length}>
+        +{Number(count) - imgUrls?.length}
+      </S.CountContainer>
+    </S.Container>
+  );
+}
+
+export default From;

--- a/src/components/Badges/From/From.style.js
+++ b/src/components/Badges/From/From.style.js
@@ -1,0 +1,47 @@
+import styled, { css } from "styled-components";
+import { COLORS } from "styles/palette";
+
+export const Container = styled.div`
+  display: flex;
+  position: relative;
+  width: 8.5rem;
+  height: 3rem;
+`;
+
+export const ImgContainer = styled.div`
+  overflow: hidden;
+  padding: 0.2rem;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  background-color: ${COLORS.WHITE};
+
+  ${({ index }) => css`
+    position: absolute;
+    left: ${index * 1.7}rem;
+  `}
+`;
+
+export const Img = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+`;
+
+export const CountContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  left: ${({ index }) => index * 1.7}rem;
+  width: 3.3rem;
+  height: 3rem;
+  border-radius: 3rem;
+  background-color: ${COLORS.WHITE};
+  color: ${COLORS.GRAY_500};
+  font-size: 1.2rem;
+  font-weight: 400;
+  line-height: 1.8rem;
+  letter-spacing: -0.006rem;
+`;

--- a/src/components/Badges/From/index.js
+++ b/src/components/Badges/From/index.js
@@ -1,0 +1,1 @@
+export { default } from "./From";

--- a/src/components/Badges/Relationship/Relationship.jsx
+++ b/src/components/Badges/Relationship/Relationship.jsx
@@ -1,0 +1,43 @@
+import * as S from "./Relationship.style";
+
+const RELATIONSHIPS = {
+  default: {
+    backgroundColor: "GRAY_100",
+    textColor: "GRAY_500",
+  },
+  acquaintance: {
+    text: "지인",
+    backgroundColor: "ORANGE_100",
+    textColor: "ORANGE_500",
+  },
+  colleague: {
+    text: "동료",
+    backgroundColor: "PURPLE_100",
+    textColor: "PURPLE_600",
+  },
+  family: {
+    text: "가족",
+    backgroundColor: "GREEN_100",
+    textColor: "GREEN_500",
+  },
+  friend: {
+    text: "친구",
+    backgroundColor: "BLUE_100",
+    textColor: "BLUE_500",
+  },
+};
+
+function Relationship({ children, relationship }) {
+  const selectedRelationship =
+    RELATIONSHIPS[relationship] ?? RELATIONSHIPS.default;
+  return (
+    <S.Container
+      backgroundColor={selectedRelationship.backgroundColor}
+      textColor={selectedRelationship.textColor}
+    >
+      {children ?? RELATIONSHIPS[relationship].text}
+    </S.Container>
+  );
+}
+
+export default Relationship;

--- a/src/components/Badges/Relationship/Relationship.style.js
+++ b/src/components/Badges/Relationship/Relationship.style.js
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+import { COLORS } from "styles/palette";
+
+export const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0px 0.8rem;
+  width: 4rem;
+  height: 2rem;
+  border-radius: 0.4rem;
+  font-size: 1.4rem;
+  font-weight: 400;
+  line-height: 2rem;
+  letter-spacing: -0.007rem;
+  background-color: ${({ backgroundColor }) => COLORS[backgroundColor]};
+  color: ${({ textColor }) => COLORS[textColor]};
+`;

--- a/src/components/Badges/Relationship/index.js
+++ b/src/components/Badges/Relationship/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Relationship";


### PR DESCRIPTION
## 구현 기능
다음 3개의 배지 컴포넌트를 구현했습니다.
- 관계 태그
- 이모지 배지
- 프로필 사진 배지 (From)

## 스크린샷
### 관계 태그
<img width="479" alt="스크린샷 2023-11-05 오후 10 13 17" src="https://github.com/codeit-part2-team4/rolling/assets/83965026/4547e39e-2f08-455a-947b-b0383f5c6d17">

### 이모지 배지
<img width="409" alt="스크린샷 2023-11-05 오후 10 28 19" src="https://github.com/codeit-part2-team4/rolling/assets/83965026/9221a08d-3c28-4d13-8d7e-d7d4c802d70c">

### From 배지
<img width="244" alt="스크린샷 2023-11-05 오후 11 11 32" src="https://github.com/codeit-part2-team4/rolling/assets/83965026/bac6aaec-964b-4762-b44f-85c0af430573">

## 사용 방법
### 관계 태그
`Relationship` 컴포넌트에 `relationship` prop으로 해당하는 관계를 전달해주어 원하는 태그를 불러올 수 있습니다.
`relation` prop으로 아무것도 전달해주지 않고 `children`으로 원하는 태그 명을 작성하면, 기본 색상 값으로 태그가 불러와집니다.

```javascript
<Relationship relationship="acquaintance" />
<Relationship relationship="colleague" />
<Relationship relationship="family" />
<Relationship relationship="friend" />
<Relationship>기타</Relationship>
```

### 이모지 태그
서버에서 이모지 데이터를 다음과 같이 불러오는 것을 토대로 컴포넌트를 구현했습니다.
```
{
  "id": 24,
  "emoji": "😀",
  "count": 15
}
```
해당 데이터 객체의 `emoji`와 `count`를 `Emoji` 컴포넌트에 각 prop으로 전달해주어 태그를 사용할 수 있습니다.
이모지 태그를 사용하는 컴포넌트들의 외부 컨테이너 설정이 동일한 것으로 보여, `Emoji.Container`도 구현해보았습니다.
```javascript
<Emoji.Container>
  <Emoji emoji="😊" count={12} />
  <Emoji emoji="👍" count={24} />
  <Emoji emoji="🎉" count={7} />
</Emoji.Container>
```

### From 배지
이미지 url을 모아둔 배열을 `imgUrls` prop으로 보내주고, 롤링 페이퍼를 작성한 모든 사람의 수를 `count` prop으로 전달해주어 사용할 수 있습니다. 이때 `count`는 전달해준 `imgUrl`의 개수를 빼서 표시해줍니다.
```javascript
const imgUrls = [
  "...",
  "...",
  "...",
];

<From imgUrls={imgUrls} count="27" />
```