### PR TITLE
fix: api 요청 timeout 시간 연장

### DIFF
--- a/src/apis/utils/fetch.js
+++ b/src/apis/utils/fetch.js
@@ -2,7 +2,7 @@ import axios from "axios";
 
 const defaultInstance = axios.create({
   baseURL: process.env.REACT_APP_BASE_URL,
-  timeout: 3000,
+  timeout: 10000,
 });
 
 const fetch = async (options) => {


### PR DESCRIPTION
## fetch timeout 시간 연장 Resolves #12 
fetch 함수에서 default instance의 timeout 시간이 짧아 데이터가 정상적으로 받아오지 않던 문제를 timeout 시간을 3초 -> 10초로 연장시켜 해결했습니다.