### PR TITLE
fix: 목록이 계속 넘어가는 현상 수정

### DIFF
--- a/src/pages/PaperListPage/PaperListPage.jsx
+++ b/src/pages/PaperListPage/PaperListPage.jsx
@@ -55,7 +55,7 @@ function PaperSection({ title, papers }) {
     setSlideIndex((prev) => prev - 1);
   };
   const slideRight = () => {
-    if (slideIndex - 1 >= papers?.count - 4) return;
+    if (slideIndex - 1 >= papers?.results?.length - 4) return;
     setSlideIndex((prev) => prev + 1);
   };
 
@@ -74,7 +74,7 @@ function PaperSection({ title, papers }) {
             <ArrowButton type="button" left onClick={slideLeft} />
           </S.ArrowButtonContainer>
         )}
-        {slideIndex < papers?.count - 4 && (
+        {slideIndex < papers?.results?.length - 4 && (
           <S.ArrowButtonContainer $right>
             <ArrowButton type="button" right onClick={slideRight} />
           </S.ArrowButtonContainer>


### PR DESCRIPTION
## Resolves #33 
페이퍼 목록 화면에서 목록이 불러온 데이터가 아닌 전체 데이터를 기반으로 계산하여 계속 넘어가는 현상을 수정했습니다.
이제 목록에서 최대 8개까지의 카드들을 불러와 확인할 수 있도록 했습니다.