### PR TITLE
refactor: useRequest refetch 함수

### DIFF
--- a/src/hooks/useRequest.js
+++ b/src/hooks/useRequest.js
@@ -1,36 +1,34 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import fetch from "apis/utils/fetch";
 
 function useRequest({ deps = [], skip = false, ...options }) {
   const [data, setData] = useState(null);
-  const [status, setStatus] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  const refetch = async (...args) => {
-    setIsLoading(true);
-    setError(null);
+  const refetch = useCallback(
+    async (...args) => {
+      setIsLoading(true);
+      setError(null);
 
-    try {
-      const { data: fetchedData, status: fetchedStatus } = await fetch({
-        ...options,
-        ...args,
-      });
-      setData(fetchedData);
-      setStatus(fetchedStatus);
-    } catch (error) {
-      setError(error);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+      try {
+        const { data } = await fetch({ ...options, ...args });
+        setData(data);
+      } catch (error) {
+        setError(error);
+      } finally {
+        setIsLoading(false);
+      }
+
+      return { data, error };
+    },
+    [options?.url, options?.method]
+  );
 
   useEffect(() => {
     if (skip) return;
     refetch();
   }, deps);
 
-  return { data, status, isLoading, error, refetch };
+  return { data, isLoading, error, refetch };
 }
-
-export default useRequest;

--- a/src/hooks/useRequest.js
+++ b/src/hooks/useRequest.js
@@ -12,15 +12,15 @@ function useRequest({ deps = [], skip = false, options }) {
       setError(null);
 
       try {
-        const { data } = await fetch({ ...options, ...args });
-        setData(data);
-      } catch (error) {
-        setError(error);
+        const { data: fetchedData } = await fetch({ ...options, ...args });
+        setData(() => fetchedData);
+        return { data: fetchedData };
+      } catch (err) {
+        setError(() => err);
+        return { error: err };
       } finally {
         setIsLoading(false);
       }
-
-      return { data, error };
     },
     [options?.url, options?.method]
   );
@@ -30,7 +30,7 @@ function useRequest({ deps = [], skip = false, options }) {
     refetch();
   }, deps);
 
-  return { data, isLoading, error, refetch: fetch };
+  return { data, isLoading, error, fetch: refetch };
 }
 
 export default useRequest;

--- a/src/hooks/useRequest.js
+++ b/src/hooks/useRequest.js
@@ -32,3 +32,5 @@ function useRequest({ deps = [], skip = false, options }) {
 
   return { data, isLoading, error, refetch: fetch };
 }
+
+export default useRequest;

--- a/src/hooks/useRequest.js
+++ b/src/hooks/useRequest.js
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback } from "react";
 import fetch from "apis/utils/fetch";
 
-function useRequest({ deps = [], skip = false, ...options }) {
+function useRequest({ deps = [], skip = false, options }) {
   const [data, setData] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -30,5 +30,5 @@ function useRequest({ deps = [], skip = false, ...options }) {
     refetch();
   }, deps);
 
-  return { data, isLoading, error, refetch };
+  return { data, isLoading, error, refetch: fetch };
 }


### PR DESCRIPTION
## 구현 내용
`useRequest` 훅에서 보내주는 `refetch` 함수를 사용할 시 `data` 및 `error`가 state로 구현되어 있어 state update를 기다려야하는 렌더링 밀림 문제가 있었습니다.
`refetch` 함수 내부에서 받아온 `data` 및 `error`을 바로 return하여 사용할 수 있도록 수정해 해결했습니다.
`status`를 받아오는 부분은 `error`을 통해 확인할 수 있기에 더 이상 필요가 없다고 판단하여 삭제하였습니다. 

## 참고사항
`...options`으로 받아오던 부분을 `option`이라는 분리된 객체로 받아 요청을 보내도록 수정했습니다.
`refetch`로 받아오던 함수를 `fetch`로 이름을 변경했습니다

## 사용 예시
이제 아래와 같이 `refetch` 함수에서 `data`를 받아서 함수 블록 내부에서 바로 사용할 수 있습니다.

```javascript
import useRequest from "hooks/useRequest";

function Test() {
  const newPaper = {
    name: "임건우",
    backgroundColor: "purple",
  };

  const { data, status, fetch } = useRequest({
    skip: true,
    options: {
      url: "recipients/",
      method: "post",
      header: {
        "Content-Type": "application/json",
      },
      data: newPaper,
    },
  });

  const postPaper = async () => {
    const { data: fetchedData, error: fetchedError } = await fetch();
    if (fetchedError) {
      alert(fetchedError);
      return;
    }
    console.log(fetchedData);
  };

  return <button onClick={postPaper}>POST</button>;
}

export default Test;

```