### PR TITLE
fix: paper card

### DIFF
--- a/src/components/Badges/From/From.jsx
+++ b/src/components/Badges/From/From.jsx
@@ -1,7 +1,8 @@
 import * as S from "./From.style";
 
 function From({ imgUrls, count }) {
-  const showMoreCount = Number(count) - imgUrls?.length;
+  const showMoreCount =
+    Number(count) - imgUrls?.length > 99 ? 99 : Number(count) - imgUrls?.length;
   return (
     <S.Container $count={count}>
       {imgUrls?.map((url, index) => {

--- a/src/components/PaperCard/PaperCard.jsx
+++ b/src/components/PaperCard/PaperCard.jsx
@@ -31,6 +31,15 @@ function PaperCard({ data = {}, slideIndex = 0 }) {
 
   const hasBackgroundImage = Boolean(backgroundImageURL);
 
+  const reduceText = (text, length) => {
+    if (!text) return;
+    if (text.length > length) {
+      return `${text.slice(0, length)}...`;
+    } else {
+      return text;
+    }
+  };
+
   return (
     <S.Container
       $slideIndex={slideIndex}
@@ -39,7 +48,9 @@ function PaperCard({ data = {}, slideIndex = 0 }) {
     >
       <S.Wrapper $hasBackgroundImage={hasBackgroundImage}>
         <S.TextContainer>
-          <S.Title $hasBackgroundImage={hasBackgroundImage}>{name}</S.Title>
+          <S.Title $hasBackgroundImage={hasBackgroundImage}>
+            {reduceText(name, 9)}
+          </S.Title>
           <From imgUrls={fromImgUrls} count={messageCount} />
           <S.Description $hasBackgroundImage={hasBackgroundImage}>
             <S.Count>{messageCount}</S.Count>명이 작성했어요!


### PR DESCRIPTION
## 수정 사항
롤링 페이퍼 카드에서 보낸 사람의 수가 세 자리수가 넘어가면 컴포넌트 바깥으로 튀어나오는 현상을 최대 99까지만 표시하도록 하여 해결했습니다.
보내는 사람의 이름이 길어질 시 잘리는 현상을 글자 수가 9 이상일 때 `...`이 뒤에 붙도록 하여 해결했습니다.

<img width="304" alt="스크린샷 2023-11-18 오후 1 43 42" src="https://github.com/Rolligo/rolling/assets/83965026/5f561971-1c02-4da2-85c8-0d06980655d7">
